### PR TITLE
Make the main script POSIX-compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ license.
 
 ## Authors
 
+* Stefan Tauner (POSIX version)
 * Henrik Bengtsson (expanded on [Gilles' implementation])
 * StackExchange user [Gilles]
 * StackExchange user [gioele]

--- a/tests/x86-64-level.sh
+++ b/tests/x86-64-level.sh
@@ -319,36 +319,37 @@ if [[ -n ${stdout} ]]; then
 fi
 
 
-echo "* x86-64-level - <<< 'flags: AVX' (exception)"
-stderr=$(x86-64-level - <<< 'flags: AVX' 2>&1)
-exit_code=$?
-if [[ ${exit_code} -eq 0 ]]; then
-    >&2 echo "ERROR: Exit code is not non-zero: ${exit_code}"
-    nerrors=$((nerrors + 1))
-fi
+for flags in "AVX2" "avx@"; do
+    echo "* x86-64-level - <<< 'flags: ${flags}' (exception)"
+    stderr=$(x86-64-level - <<< "flags: ${flags}" 2>&1)
+    exit_code=$?
+    if [[ ${exit_code} -eq 0 ]]; then
+        >&2 echo "ERROR: Exit code is not non-zero: ${exit_code}"
+        nerrors=$((nerrors + 1))
+    fi
 
-if [[ -z ${stderr} ]]; then
-    >&2 echo "ERROR: No error message: '${stderr}'"
-    nerrors=$((nerrors + 1))
-fi
+    if [[ -z ${stderr} ]]; then
+        >&2 echo "ERROR: No error message: '${stderr}'"
+        nerrors=$((nerrors + 1))
+    fi
 
-if ! head -n 1 <<< "${stderr}" | grep -q -E "^ERROR:"; then
-    >&2 echo "ERROR: Standard error output does not begin with 'ERROR:': '${stderr}'"
-    nerrors=$((nerrors + 1))
-fi
+    if ! head -n 1 <<< "${stderr}" | grep -q -E "^ERROR:"; then
+        >&2 echo "ERROR: Standard error output does not begin with 'ERROR:': '${stderr}'"
+        nerrors=$((nerrors + 1))
+    fi
 
-if ! grep -q -E "^ERROR: .*format of the CPU flags" <<< "${stderr}"; then
-    >&2 echo "ERROR: Unexpected error message: '${stderr}'"
-    nerrors=$((nerrors + 1))
-fi
+    if ! grep -q -E "^ERROR: .*format of the CPU flags" <<< "${stderr}"; then
+        >&2 echo "ERROR: Unexpected error message: '${stderr}'"
+        nerrors=$((nerrors + 1))
+    fi
 
-## Outputs nothing to stdout
-stdout=$( x86-64-level - <<< 'flags: AVX' 2> /dev/null )
-if [[ -n ${stdout} ]]; then
-    >&2 echo "ERROR: Detected output to standard output: ${stdout}"
-    nerrors=$((nerrors + 1))
-fi
-
+    ## Outputs nothing to stdout
+    stdout=$( x86-64-level - <<< 'flags: AVX' 2> /dev/null )
+    if [[ -n ${stdout} ]]; then
+        >&2 echo "ERROR: Detected output to standard output: ${stdout}"
+        nerrors=$((nerrors + 1))
+    fi
+done
 
 
 #--------------------------------------------------------------------------

--- a/tests/x86-64-level.sh
+++ b/tests/x86-64-level.sh
@@ -167,12 +167,12 @@ for truth in $(seq 0 "$((${#cpu_flags[@]} - 1))"); do
         >&2 echo "ERROR: Exit code is non-zero: ${exit_code}"
         nerrors=$((nerrors + 1))
     fi
-    
+
     if [[ "${level}" -ne "${truth}" ]]; then
         >&2 echo "ERROR: Unexpected level: ${level} != ${truth}"
         nerrors=$((nerrors + 1))
-    fi    
-    
+    fi
+
     ## Outputs nothing to stderr
     stderr=$( { >&2 x86-64-level <<< "flags: ${flags}" > /dev/null; } 2>&1 )
     if [[ -n ${stderr} ]]; then
@@ -196,22 +196,22 @@ for level in -1 0 5 100; do
         >&2 echo "ERROR: Exit code should be non-zero: ${exit_code}"
         nerrors=$((nerrors + 1))
     fi
-    
+
     if [[ -z ${stderr} ]]; then
         >&2 echo "ERROR: No error message: '${stderr}'"
         nerrors=$((nerrors + 1))
-    fi    
-    
+    fi
+
     if ! head -n 1 <<< "${stderr}" | grep -q -E "^ERROR:"; then
         >&2 echo "ERROR: Standard error output does not begin with 'ERROR:': '${stderr}'"
         nerrors=$((nerrors + 1))
     fi
-    
+
     if ! grep -q -E "^ERROR: .*out of range.* ${level}" <<< "${stderr}"; then
         >&2 echo "ERROR: Unexpected error message: '${stderr}'"
         nerrors=$((nerrors + 1))
-    fi    
-    
+    fi
+
     ## Outputs nothing to stdout
     stdout=$(x86-64-level --assert="${level}" 2> /dev/null)
     if [[ -n ${stdout} ]]; then
@@ -230,22 +230,22 @@ for level in 1.2 world; do
         >&2 echo "ERROR: Exit code should be non-zero: ${exit_code}"
         nerrors=$((nerrors + 1))
     fi
-    
+
     if [[ -z ${stderr} ]]; then
         >&2 echo "ERROR: No error message: '${stderr}'"
         nerrors=$((nerrors + 1))
-    fi    
+    fi
 
     if ! head -n 1 <<< "${stderr}" | grep -q -E "^ERROR:"; then
         >&2 echo "ERROR: Standard error output does not begin with 'ERROR:': '${stderr}'"
         nerrors=$((nerrors + 1))
-    fi    
+    fi
 
     if ! grep -q -E "^ERROR: .*does not specify an integer.* ${level}" <<< "${stderr}"; then
         >&2 echo "ERROR: Unexpected error message: '${stderr}'"
         nerrors=$((nerrors + 1))
-    fi    
-    
+    fi
+
     ## Outputs nothing to stdout
     stdout=$(x86-64-level --assert="${level}" 2> /dev/null)
     if [[ -n ${stdout} ]]; then
@@ -268,17 +268,17 @@ fi
 if [[ -z ${stderr} ]]; then
     >&2 echo "ERROR: No error message: '${stderr}'"
     nerrors=$((nerrors + 1))
-fi    
+fi
 
 if ! head -n 1 <<< "${stderr}" | grep -q -E "^ERROR:"; then
     >&2 echo "ERROR: Standard error output does not begin with 'ERROR:': '${stderr}'"
     nerrors=$((nerrors + 1))
-fi    
+fi
 
 if ! grep -q -E "^ERROR: .*must not be empty" <<< "${stderr}"; then
     >&2 echo "ERROR: Unexpected error message: '${stderr}'"
     nerrors=$((nerrors + 1))
-fi    
+fi
 
 ## Outputs nothing to stdout
 stdout=$(x86-64-level --assert="" 2> /dev/null)
@@ -299,17 +299,17 @@ fi
 if [[ -z ${stderr} ]]; then
     >&2 echo "ERROR: No error message: '${stderr}'"
     nerrors=$((nerrors + 1))
-fi    
+fi
 
 if ! head -n 1 <<< "${stderr}" | grep -q -E "^ERROR:"; then
     >&2 echo "ERROR: Standard error output does not begin with 'ERROR:': '${stderr}'"
     nerrors=$((nerrors + 1))
-fi    
+fi
 
 if ! grep -q -E "^ERROR: .*Input data is empty" <<< "${stderr}"; then
     >&2 echo "ERROR: Unexpected error message: '${stderr}'"
     nerrors=$((nerrors + 1))
-fi    
+fi
 
 ## Outputs nothing to stdout
 stdout=$( x86-64-level - <<< '' 2> /dev/null )
@@ -330,17 +330,17 @@ fi
 if [[ -z ${stderr} ]]; then
     >&2 echo "ERROR: No error message: '${stderr}'"
     nerrors=$((nerrors + 1))
-fi    
+fi
 
 if ! head -n 1 <<< "${stderr}" | grep -q -E "^ERROR:"; then
     >&2 echo "ERROR: Standard error output does not begin with 'ERROR:': '${stderr}'"
     nerrors=$((nerrors + 1))
-fi    
+fi
 
 if ! grep -q -E "^ERROR: .*format of the CPU flags" <<< "${stderr}"; then
     >&2 echo "ERROR: Unexpected error message: '${stderr}'"
     nerrors=$((nerrors + 1))
-fi    
+fi
 
 ## Outputs nothing to stdout
 stdout=$( x86-64-level - <<< 'flags: AVX' 2> /dev/null )

--- a/x86-64-level
+++ b/x86-64-level
@@ -75,9 +75,9 @@ data=
 read_input() {
     if [ -z "${data}" ]; then
         if ${stdin}; then
-            data=$(< /dev/stdin)
+            data=$(cat /dev/stdin)
         else
-            data=$(< /proc/cpuinfo)
+            data=$(cat /proc/cpuinfo)
         fi
         if [ -z "${data}" ]; then
             echo >&2 "ERROR: Input data is empty"

--- a/x86-64-level
+++ b/x86-64-level
@@ -87,7 +87,6 @@ read_input() {
 }
 
 get_cpu_name() {
-    local name
     bfr=$(grep -E "^model name[[:space:]]*:" <<< "${data}")
     name=$(echo "${bfr}" | head -n 1)
     name="${name#model name*:}"
@@ -96,7 +95,6 @@ get_cpu_name() {
 
 
 get_cpu_flags() {
-    local flags
     flags=$(grep "^flags[[:space:]]*:" <<< "${data}" | head -n 1)
     flags="${flags#*:}"
     flags="${flags## }"
@@ -115,10 +113,6 @@ validate_cpu_flags() {
 
 
 has_cpu_flags() {
-    local flag
-    local msg
-    local cpu_name
-
     for flag; do
         ## Note, it's important to keep a trailing space
         case " ${flags} " in

--- a/x86-64-level
+++ b/x86-64-level
@@ -46,6 +46,7 @@
 #' Source code: https://github.com/ucsf-wynton/wynton-tools
 #'
 #' Authors:
+#' * Stefan Tauner (POSIX version)
 #' * Henrik Bengtsson (expanded on Gilles implementation [2])
 #' * StackExchange user 'Gilles'
 #'   <https://stackexchange.com/users/164368/>

--- a/x86-64-level
+++ b/x86-64-level
@@ -87,18 +87,17 @@ read_input() {
 }
 
 get_cpu_name() {
-    bfr=$(grep -E "^model name[[:space:]]*:" <<< "${data}")
-    name=$(echo "${bfr}" | head -n 1)
+    name=$(echo "${data}" | grep -E "^model name[[:space:]]*:" | head -n 1)
     name="${name#model name*:}"
     echo "${name## }"
 }
 
 
 get_cpu_flags() {
-    flags=$(grep "^flags[[:space:]]*:" <<< "${data}" | head -n 1)
+    flags=$(echo "${data}" | grep "^flags[[:space:]]*:" | head -n 1)
     flags="${flags#*:}"
     flags="${flags## }"
-    if grep -v -q -E "^[[:lower:][:digit:]_ ]+$" <<< "${flags}"; then
+    if [ "${flags}" != "${flags#*[!a-z0-9_ ]*}" ]; then
         echo >&2 "ERROR: Cannot reliably infer the CPU x86-64 level, because the format of the CPU flags comprise of other symbols than only lower-case letters, digits, and underscores: '${flags}'"
         exit 1
     fi

--- a/x86-64-level
+++ b/x86-64-level
@@ -118,7 +118,7 @@ has_cpu_flags() {
     local flag
     local msg
     local cpu_name
-    
+
     for flag; do
         ## Note, it's important to keep a trailing space
         case " ${flags} " in
@@ -144,7 +144,7 @@ level=0
 determine_cpu_version() {
     ## x86-64-v0 (can this happen?)
     level=0
-    
+
     ## x86-64-v1
     has_cpu_flags lm cmov cx8 fpu fxsr mmx syscall sse2 || return 0
     level=1
@@ -152,7 +152,7 @@ determine_cpu_version() {
     ## x86-64-v2
     has_cpu_flags cx16 lahf_lm popcnt sse4_1 sse4_2 ssse3 || return 0
     level=2
-    
+
     ## x86-64-v3
     has_cpu_flags avx avx2 bmi1 bmi2 f16c fma abm movbe xsave || return 0
     level=3

--- a/x86-64-level
+++ b/x86-64-level
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 #' Get the x86-64 Microarchitecture Level on the Current Machine
 #'
 #' Queries the CPU information to infer which level of x86-64

--- a/x86-64-level
+++ b/x86-64-level
@@ -73,13 +73,13 @@ version() {
 #---------------------------------------------------------------------
 data=
 read_input() {
-    if [[ -z ${data} ]]; then
+    if [ -z "${data}" ]; then
         if ${stdin}; then
             data=$(< /dev/stdin)
         else
             data=$(< /proc/cpuinfo)
         fi
-        if [[ -z ${data} ]]; then
+        if [ -z "${data}" ]; then
             echo >&2 "ERROR: Input data is empty"
             exit 1
         fi
@@ -123,7 +123,7 @@ has_cpu_flags() {
                 if ${verbose}; then
                     msg="Identified x86-64-v${level}, because x86-64-v$((level + 1)) requires '${flag}', which is not supported by this CPU"
                     cpu_name=$(get_cpu_name)
-                    [[ -n ${cpu_name} ]] && msg="${msg} [${cpu_name}]"
+                    [ -n "${cpu_name}" ] && msg="${msg} [${cpu_name}]"
                     echo >&2 "${msg}"
                 fi
                 return 1
@@ -160,7 +160,7 @@ determine_cpu_version() {
 report_cpu_version() {
     read_input
     flags=$(get_cpu_flags)
-    if [[ -z ${flags} ]]; then
+    if [ -z "${flags}" ]; then
         echo >&2 "ERROR: No CPU 'flags' entry in the input data"
         exit 1
     fi
@@ -222,13 +222,13 @@ while [ $# -gt 0 ]; do
     shift
 done
 
-if [[ -n ${assert} ]]; then
+if [ -n "${assert}" ]; then
     validate_cpu_flags
     version=$(report_cpu_version)
-    if [[ ${version} -lt ${assert} ]]; then
+    if [ "${version}" -lt "${assert}" ]; then
         read_input
         cpu_info=$(get_cpu_name)
-        [[ -n ${cpu_info} ]] && cpu_info=" [${cpu_info}]"
+        [ -n "${cpu_info}" ] && cpu_info=" [${cpu_info}]"
         >&2 echo "The CPU${cpu_info} on this host ('$(hostname)') supports x86-64-v${version}, which is less than the required x86-64-v${assert}"
         exit 1
     fi

--- a/x86-64-level
+++ b/x86-64-level
@@ -177,46 +177,48 @@ stdin=false
 assert=
 
 # Parse command-line options
-while [[ $# -gt 0 ]]; do
+while [ $# -gt 0 ]; do
+    case $1 in
     ## Options (--flags):
-    if [[ "$1" == "--help" ]]; then
-        help
-        exit 0
-    elif [[ "$1" == "--version" ]]; then
-        version
-        exit 0
-    elif [[ "$1" == "--verbose" ]]; then
-        verbose=true
-    elif [[ "$1" == "-" ]]; then
-        stdin=true
-    elif [[ "$1" == "--assert" ]]; then
-        verbose=true
+        --help)
+            help
+            exit 0;;
+        --version)
+            version
+            exit 0;;
+        --verbose)
+            verbose=true;;
+        -)
+            stdin=true;;
     ## Options (--key=value):
-    elif [[ "$1" =~ ^--.*=.*$ ]]; then
-        key=${1//--}
-        key=${key//=*}
-        value=${1//--[[:alpha:]]*=}
-        if [[ -z ${value} ]]; then
-            echo >&2 "ERROR: Option '--${key}' must not be empty"
-            exit 2
-        fi
-        if [[ "${key}" == "assert" ]]; then
-            assert=${value}
-            if [[ ! ${assert} =~ ^-?[0-9]+$ ]]; then
-                echo >&2 "ERROR: Option --assert does not specify an integer: ${assert}"
-                exit 2
-            elif [[ ${assert} -lt 1 ]] || [[ ${assert} -gt 4 ]]; then
-                echo >&2 "ERROR: Option --assert is out of range [1,4]: ${assert}"
+        --*=*)
+            pair=${1#--}
+            key=${pair%%=*}
+            value=${pair#*=}
+            if [ -z "${value}" ]; then
+                echo >&2 "ERROR: Option '--${key}' must not be empty"
                 exit 2
             fi
-        else
+            if [ "${key}" = "assert" ]; then
+                case $value in
+                    '' | *[!0-9-]*)
+                    echo >&2 "ERROR: Option --assert does not specify an integer: ${value}"
+                    exit 2
+                esac
+                if [ "${value}" -lt 1 ] || [ "${value}" -gt 4 ]; then
+                    echo >&2 "ERROR: Option --assert is out of range [1,4]: ${value}"
+                    exit 2
+                fi
+                assert=${value}
+            else
+                echo >&2 "ERROR: Unknown option: $key"
+                exit 2
+            fi
+            ;;
+        *)
             echo >&2 "ERROR: Unknown option: $1"
-            exit 2
-        fi
-    else
-        echo >&2 "ERROR: Unknown option: $1"
-        exit 2
-    fi
+            exit 2;;
+    esac
     shift
 done
 

--- a/x86-64-level
+++ b/x86-64-level
@@ -233,7 +233,7 @@ if [[ -n ${assert} ]]; then
         read_input
         cpu_info=$(get_cpu_name)
         [[ -n ${cpu_info} ]] && cpu_info=" [${cpu_info}]"
-        >&2 echo "The CPU${cpu_info} on this host ('${HOSTNAME}') supports x86-64-v${version}, which is less than the required x86-64-v${assert}"
+        >&2 echo "The CPU${cpu_info} on this host ('$(hostname)') supports x86-64-v${version}, which is less than the required x86-64-v${assert}"
         exit 1
     fi
 else


### PR DESCRIPTION
I think scripts that are supposed as aids in compatibility checks should be most compatible themselves. Therefore I've spent some time on getting rid all the bashism in the main script. Performance is certainly impacted (and most probably slightly negatively) but I've tried to keep everything backward-compatible including the argument checks. All tests keep passing throughout the patch series.