### PR TITLE
Add FreeBSD support

### DIFF
--- a/x86-64-level
+++ b/x86-64-level
@@ -77,7 +77,15 @@ read_input() {
         if ${stdin}; then
             data=$(< /dev/stdin)
         else
-            data=$(< /proc/cpuinfo)
+            if [ -r /proc/cpuinfo ]; then
+                data=$(< /proc/cpuinfo)
+            elif [ -r /var/run/dmesg.boot ]; then
+                # FreeBSD
+                data=$(< /var/run/dmesg.boot)
+            else
+                echo >&2 "ERROR: Unsupported system"
+                exit 1
+            fi
         fi
         if [[ -z ${data} ]]; then
             echo >&2 "ERROR: Input data is empty"
@@ -98,8 +106,22 @@ get_cpu_name() {
 get_cpu_flags() {
     local flags
     flags=$(grep "^flags[[:space:]]*:" <<< "${data}" | head -n 1)
-    flags="${flags#*:}"
-    flags="${flags## }"
+    if [ -z "${flags}" ]; then
+        # FreeBSD
+        flags=$(grep "Features.*=" <<< "${data}" | sort | uniq | cut -d '<' -f 2 | cut -d '>' -f 1)
+        flags=$(paste -s -d ',' - <<< "${flags}")
+        flags=$(echo "${flags//MMX+/mmxext}")
+        flags=$(echo "${flags//3DNow!+/3dnowext}")
+        flags=$(echo "${flags//3DNow!/3dnow}")
+        flags=$(echo "${flags//MMX+/mmxext}")
+        flags=$(echo "${flags//LAHF/lahf_lm}")
+        flags=$(echo "${flags//./_}")
+        flags=$(echo "${flags//,/ }")
+        flags=$(echo "${flags@L}")
+    else
+        flags="${flags#*:}"
+        flags="${flags## }"
+    fi
     if grep -v -q -E "^[[:lower:][:digit:]_ ]+$" <<< "${flags}"; then
         echo >&2 "ERROR: Cannot reliably infer the CPU x86-64 level, because the format of the CPU flags comprise of other symbols than only lower-case letters, digits, and underscores: '${flags}'"
         exit 1


### PR DESCRIPTION
Adding support, tested on  Intel Xeon Platinum 8259CL and AMD EPYC 7502P.

I didn’t map all CPU features name, but only the mandatories like [`MMX+ -> mmxext`](https://github.com/freebsd/freebsd-src/blob/main/sys/x86/x86/identcpu.c#L890).

```
$ uname -a
FreeBSD15.0-CURRENT FreeBSD 15.0-CURRENT #0 master-n6860-b5e4f003d8ca-dirty: Thu May  2 22:21:20 UTC 2024
$ grep Features /var/run/dmesg.boot | sort | uniq
  AMD Features2=0x121<LAHF,ABM,Prefetch>
  AMD Features=0x2c100800<SYSCALL,NX,Page1GB,RDTSCP,LM>
  Features2=0x7ffefbff<SSE3,PCLMULQDQ,DTES64,MON,DS_CPL,VMX,SMX,EST,TM2,SSSE3,SDBG,FMA,CX16,xTPR,PDCM,PCID,DCA,SSE4.1,SSE4.2,x2APIC,MOVBE,POPCNT,TSCDLT,AESNI,XSAVE,OSXSAVE,AVX,F16C,RDRAND>
  Features=0xbfebfbff<FPU,VME,DE,PSE,TSC,MSR,PAE,MCE,CX8,APIC,SEP,MTRR,PGE,MCA,CMOV,PAT,PSE36,CLFLUSH,DTS,ACPI,MMX,FXSR,SSE,SSE2,SS,HTT,TM,PBE>
  Structured Extended Features2=0x818<PKU,OSPKE,AVX512VNNI>
  Structured Extended Features3=0xbc000400<MD_CLEAR,IBPB,STIBP,L1DFL,ARCH_CAP,SSBD>
  Structured Extended Features=0xd39ffffb<FSGSBASE,TSCADJ,BMI1,HLE,AVX2,FDPEXC,SMEP,BMI2,ERMS,INVPCID,RTM,PQM,NFPUSG,MPX,PQE,AVX512F,AVX512DQ,RDSEED,ADX,SMAP,CLFLUSHOPT,CLWB,PROCTRACE,AVX512CD,AVX512BW,AVX512VL>
  XSAVE Features=0xf<XSAVEOPT,XSAVEC,XINUSE,XSAVES>

$ ./x86-64-level
4
```